### PR TITLE
Modernize plugin bootstrap and bump version 5.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Parsi Date
 
-![Version](https://img.shields.io/badge/version-5.1.2-blue)
-![WordPress Compatible](https://img.shields.io/badge/WordPress-5.3%20to%206.7.1-blue)
+![Version](https://img.shields.io/badge/version-5.2.0-blue)
+![WordPress Compatible](https://img.shields.io/badge/WordPress-5.3%20to%206.8-blue)
 
 **Contributors:** [lord_viper](https://profiles.wordpress.org/lord_viper), [man4toman](https://profiles.wordpress.org/man4toman), [parselearn](https://profiles.wordpress.org/parselearn), [yazdaniwp](https://profiles.wordpress.org/yazdaniwp), [saeedfard](https://profiles.wordpress.org/saeedfard), [iehsanir](https://profiles.wordpress.org/iehsanir)  
 **Donate link:** [https://wp-parsi.com/support/](https://wp-parsi.com/support/)  
 **Tags:** shamsi, wp-parsi, wpparsi, persian, parsi, farsi, jalali, date, calendar, i18n, l10n, iran, iranian, parsidate, rtl, gutenberg, acf, woocommerce  
 **Requires at least:** 5.3  
-**Tested up to:** 6.7.1  
-**Stable tag:** 5.1.2  
+**Tested up to:** 6.8
+**Stable tag:** 5.2.0
 
 Persian date support for WordPress.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wp-parsi.com/support/
 Tags: shamsi, persian, jalali, date, woocommerce, ووکامرس, تاریخ شمسی, پارسی دیت, پارسی‌دیت
 Requires at least: 5.3
 Tested up to: 6.8
-Stable tag: 5.1.8
+Stable tag: 5.2.0
 License: GPLv3
 
 Persian date support for WordPress
@@ -46,6 +46,11 @@ List of some features:
 6. Persian date type in ACF
 
 == Changelog ==
+
+= 5.2.0 =
+* Refreshed the plugin bootstrap with modern PHP 7.4+ features and stricter typing.
+* Centralized hook registration and dependency loading for a cleaner initialization flow.
+* Added safeguards around multilingual checks to avoid unnecessary early returns.
 
 = 5.1.8 =
 * Improved multilingual compatibility


### PR DESCRIPTION
## Summary
- refactor the main plugin bootstrap to use typed properties, strict types, and centralized hook registration
- add safeguards around multilingual gating while keeping dependency loading encapsulated
- bump the advertised plugin version and documentation metadata to 5.2.0 with an updated changelog entry